### PR TITLE
Adding ability to supply different config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,21 @@ Then configure the rules you want to use under the rules section.
 
 ```json
 {
-    "rules": {
-        "hbs/rule-name": 2
-    }
+  "rules": {
+      'hbs/check-hbs-template-literals': 2
+  }
 }
+```
+
+or
+
+```
+  "rules": {
+    'hbs/check-hbs-template-literals': [
+      'error', 2,
+      {'ConfigFile': __dirname + '/.eslint-template-lintrc.json'}
+    ],
+  }
 ```
 
 The plugin will report the number of errors and the first line of the first error. Here's a running example. Left-hand side is the output of `eslint` from the command-line, right-hand side is `vim` running with `eslint` (via syntastic):

--- a/lib/rules/check-hbs-template-literals.js
+++ b/lib/rules/check-hbs-template-literals.js
@@ -4,13 +4,14 @@
  */
 'use strict'
 const TemplateLinter = require('ember-template-lint')
-const linter = new TemplateLinter()
+const fs = require('fs')
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = {
+
   meta: {
     docs: {
       description:
@@ -18,13 +19,46 @@ module.exports = {
       category: 'Literal linting',
       recommended: false
     },
-    fixable: null, // or "code" or "whitespace"
+    fixable: null,
     schema: [
-      // fill in your schema
+      {
+        oneOf: [
+          {
+            enum: ['tab']
+          },
+          {
+            type: 'integer',
+            minimum: 0
+          }
+        ]
+      },
+      {
+        type: 'object',
+        properties: {
+          'ConfigFile': {
+            type: 'string'
+          },
+        },
+        additionalProperties: false,
+      },
     ]
   },
 
   create: function(context) {
+    let config = {}
+    let linter
+    if (context.options.length > 1) {
+      const extendedOptions = context.options[1]
+      const filename = extendedOptions.ConfigFile
+      if (filename && fs.existsSync(filename)) {
+        config = JSON.parse(fs.readFileSync(filename))
+        linter = new TemplateLinter({config})
+      }
+    }
+    if (!linter) {
+      linter = new TemplateLinter()
+    }
+
     //----------------------------------------------------------------------
     // Public
     //----------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-hbs",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "Provide linting for hbs template literals inside of JavaScript",
   "keywords": [
     "eslint",


### PR DESCRIPTION
Some template-check plugins should work differently when checking inlined templates than when checking templates in an `.hbs` file. This PR allows a user to pass in the config for a separate filename for ember-template-lint.