### PR TITLE
Use file path to lint template

### DIFF
--- a/lib/rules/check-hbs-template-literals.js
+++ b/lib/rules/check-hbs-template-literals.js
@@ -75,7 +75,7 @@ module.exports = {
           if (node.quasi.type === 'TemplateLiteral') {
             let hbs = node.quasi.quasis[0].value.cooked
             hbs = unindentAndStripSafeNewlines(hbs)
-            const results = linter.verify({source: hbs.toString(), moduleId: context.id})
+            const results = linter.verify({source: hbs.toString(), filePath: context.id, moduleId: context.id})
             if (results.length !== 0) {
               const firstLine = results[0].message.split('\n')[0]
               const msg = `${results.length} error(s): ${firstLine}`


### PR DESCRIPTION
This PR fixes error `The "path" argument must be of type string. Received type undefined` introduced by this [fix](https://github.com/ember-template-lint/ember-template-lint/pull/1072) 🙈.

fixes ember-template-lint/ember-template-lint#1161